### PR TITLE
wasm32: implement setjmp/longjmp via LLVM Wasm SjLj lowering

### DIFF
--- a/arch/wasm32/arch.mak
+++ b/arch/wasm32/arch.mak
@@ -17,5 +17,5 @@ LIBCC =
 # "indirect use of setjmp" or collides with the __wasm_longjmp symbol.
 WASM_SJLJ_OBJS = \
 	obj/src/setjmp/wasm32/wasm_longjmp.o obj/src/setjmp/wasm32/wasm_longjmp.lo \
-	obj/src/signal/siglongjmp.o obj/src/signal/siglongjmp.lo
+	obj/src/signal/wasm32/siglongjmp.o obj/src/signal/wasm32/siglongjmp.lo
 $(WASM_SJLJ_OBJS): CFLAGS_ALL += -mllvm -wasm-enable-sjlj

--- a/arch/wasm32/arch.mak
+++ b/arch/wasm32/arch.mak
@@ -3,3 +3,19 @@ CFLAGS += --target=wasm32 -matomics -mbulk-memory
 LDFLAGS =
 CROSS_COMPILE = llvm-
 LIBCC =
+
+# longjmp is implemented with LLVM's Wasm SjLj lowering. __wasm_longjmp uses
+# __builtin_wasm_throw, and any musl translation unit that itself calls longjmp
+# (siglongjmp) must be compiled with the pass enabled so the call is rewritten.
+# Scoped to these objects so the rest of libc stays free of the Wasm
+# exception-handling feature; a guest only requires it if it uses setjmp.
+#
+# Only wasm_longjmp.c (the __builtin_wasm_throw helper) and siglongjmp.c (which
+# calls longjmp) go through the pass. setjmp.c and longjmp.c are excluded: the
+# setjmp/longjmp helpers are plain memory writes, and running the pass over the
+# real setjmp/longjmp definitions rejects the _setjmp/_longjmp weak aliases as
+# "indirect use of setjmp" or collides with the __wasm_longjmp symbol.
+WASM_SJLJ_OBJS = \
+	obj/src/setjmp/wasm32/wasm_longjmp.o obj/src/setjmp/wasm32/wasm_longjmp.lo \
+	obj/src/signal/siglongjmp.o obj/src/signal/siglongjmp.lo
+$(WASM_SJLJ_OBJS): CFLAGS_ALL += -mllvm -wasm-enable-sjlj

--- a/arch/wasm32/bits/syscall.h.in
+++ b/arch/wasm32/bits/syscall.h.in
@@ -328,5 +328,12 @@
 #define __NR_vmsplice 75
 #define __NR_wait4 260
 #define __NR_waitid 95
+#define __NR_wasm_sem_getvalue (__NR_arch_specific_syscall + 7)
+#define __NR_wasm_sem_open (__NR_arch_specific_syscall + 1)
+#define __NR_wasm_sem_post (__NR_arch_specific_syscall + 6)
+#define __NR_wasm_sem_timedwait (__NR_arch_specific_syscall + 5)
+#define __NR_wasm_sem_trywait (__NR_arch_specific_syscall + 4)
+#define __NR_wasm_sem_unlink (__NR_arch_specific_syscall + 2)
+#define __NR_wasm_sem_wait (__NR_arch_specific_syscall + 3)
 #define __NR_write 64
 #define __NR_writev 66

--- a/arch/wasm32/crt_arch.h
+++ b/arch/wasm32/crt_arch.h
@@ -1,8 +1,4 @@
-struct wasm_process_args {
-	int len, envc, argc;
-	char **argv, **envp;
-	char data[];
-};
+#include "process_args.h"
 
 __attribute__((import_module("linux"), import_name("get_args_length")))
 int wasm_get_args_length(void);
@@ -11,7 +7,7 @@ int wasm_get_args(struct wasm_process_args *buf);
 
 // TODO: malloc this once mmap is fixed
 static char args_buf[65536 * 4];
-static struct wasm_process_args *args = (void*)args_buf;
+hidden struct wasm_process_args *__wasm_process_args = (void*)args_buf;
 
 #ifdef START_is_dlstart
 hidden void _dlstart_c(size_t *sp, size_t *dynv);
@@ -22,19 +18,16 @@ hidden void _dlstart(void) {
 
 #ifdef START_is_start
 void __wasm_call_ctors(void);
-weak int __main_void(void) {
-	int __main_argc_argv(int argc, char **argv);
-	return __main_argc_argv(args->argc, args->argv);
-}
+int __main_void(void);
 hidden void _start_c(long *p);
 hidden void _start(void) {
 	int len = wasm_get_args_length();
 	if (len < 0) __builtin_trap();
 	if (len > sizeof(args_buf)) __builtin_trap();
 
-	if (wasm_get_args(args) < 0) __builtin_trap();
+	if (wasm_get_args(__wasm_process_args) < 0) __builtin_trap();
 
-	__init_libc(args->envp, args->argv[0]);
+	__init_libc(__wasm_process_args->envp, __wasm_process_args->argv[0]);
 	__libc_start_init();
 	__wasm_call_ctors();
 

--- a/arch/wasm32/process_args.h
+++ b/arch/wasm32/process_args.h
@@ -1,0 +1,12 @@
+#ifndef _WASM32_PROCESS_ARGS_H
+#define _WASM32_PROCESS_ARGS_H
+
+struct wasm_process_args {
+	int len, envc, argc;
+	char **argv, **envp;
+	char data[];
+};
+
+extern hidden struct wasm_process_args *__wasm_process_args;
+
+#endif

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -18,10 +18,8 @@ typedef struct {
 	volatile int __val[4*sizeof(long)/sizeof(int)];
 } sem_t;
 
-#ifndef __wasm__
 int    sem_close(sem_t *);
 sem_t *sem_open(const char *, int, ...);
-#endif
 int    sem_destroy(sem_t *);
 int    sem_getvalue(sem_t *__restrict, int *__restrict);
 int    sem_init(sem_t *, int, unsigned);

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -27,6 +27,12 @@ typedef struct __jmp_buf_tag {
 typedef jmp_buf sigjmp_buf;
 int sigsetjmp (sigjmp_buf, int) __setjmp_attr;
 _Noreturn void siglongjmp (sigjmp_buf, int);
+#ifdef __wasm__
+struct __jmp_buf_tag *__wasm_sigsetjmp_prepare(sigjmp_buf, int);
+/* LLVM's Wasm SjLj pass must see setjmp directly in the caller. */
+#define sigsetjmp(env, savemask) \
+	setjmp(__wasm_sigsetjmp_prepare((env), (savemask)))
+#endif
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \

--- a/src/env/wasm32/__main_argc_argv.c
+++ b/src/env/wasm32/__main_argc_argv.c
@@ -1,0 +1,9 @@
+#include <features.h>
+#include "process_args.h"
+
+int __main_argc_argv_envp(int, char **, char **);
+
+weak int __main_argc_argv(int argc, char **argv)
+{
+	return __main_argc_argv_envp(argc, argv, __wasm_process_args->envp);
+}

--- a/src/env/wasm32/__main_void.c
+++ b/src/env/wasm32/__main_void.c
@@ -1,0 +1,10 @@
+#include <features.h>
+#include "process_args.h"
+
+int __main_argc_argv(int, char **);
+
+weak int __main_void(void)
+{
+	return __main_argc_argv(__wasm_process_args->argc,
+		__wasm_process_args->argv);
+}

--- a/src/include/sys/mman.h
+++ b/src/include/sys/mman.h
@@ -13,9 +13,9 @@ hidden int __munmap(void *, size_t);
 hidden void *__mremap(void *, size_t, size_t, int, ...);
 hidden int __madvise(void *, size_t, int);
 hidden int __mprotect(void *, size_t, int);
+#endif
 
 hidden char *__shm_mapname(const char *, char *);
-#endif
 
 hidden const unsigned char *__map_file(const char *, size_t *);
 hidden void __unmap_file(const char *, size_t);

--- a/src/internal/wasm_sem.h
+++ b/src/internal/wasm_sem.h
@@ -1,0 +1,18 @@
+#ifndef WASM_SEM_H
+#define WASM_SEM_H
+
+#include <semaphore.h>
+
+#define WASM_SEM_TAG 0x73656d66
+
+static inline int __wasm_sem_is_named(const sem_t *sem)
+{
+	return sem->__val[3] == WASM_SEM_TAG;
+}
+
+static inline int __wasm_sem_fd(const sem_t *sem)
+{
+	return sem->__val[0];
+}
+
+#endif

--- a/src/linux/brk.c
+++ b/src/linux/brk.c
@@ -12,18 +12,37 @@ static void *heap_limit;
 static void *current = &__heap_end;
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
+// Keep at least one page of backed linear memory beyond the program break.
+//
+// On a conventional target sbrk hands out page-granular memory and the bytes
+// between the break and the end of its page stay accessible, so the small
+// over-reads that C code performs just past a heap allocation (word-at-a-time
+// and page-rounded scans in libc and in programs like GNU coreutils) are
+// harmless. wasm linear memory has no such slack of its own: an access at or
+// beyond memory.size traps. Because malloc here draws from sbrk and packs
+// allocations directly against the break, a break landing on a 64KiB memory
+// boundary leaves the top allocation abutting unbacked memory, and an otherwise
+// benign over-read traps with "memory access out of bounds". Reserving a guard
+// page past the break restores the page-granular read slack those programs
+// rely on.
+#define BRK_GUARD PAGESIZE
+
 static int _brk(void *end) {
 	if (!heap_limit)
 		heap_limit = (void *)(__builtin_wasm_memory_size(0) * PAGESIZE);
 
 	if (end < current) goto fail;
 
-	if (end <= heap_limit) {
+	// The break itself is `end`; grow memory so the guard page past it is
+	// backed too.
+	uintptr_t want = (uintptr_t)end + BRK_GUARD;
+
+	if (want <= (uintptr_t)heap_limit) {
 		current = end;
 		return 0;
 	}
 
-	size_t bytes = (uintptr_t)end - (uintptr_t)heap_limit;
+	size_t bytes = want - (uintptr_t)heap_limit;
 	size_t pages = (bytes + PAGESIZE - 1) / PAGESIZE;
 
 	if (__builtin_wasm_memory_grow(0, pages) == SIZE_MAX) goto fail;

--- a/src/setjmp/wasm32/longjmp.c
+++ b/src/setjmp/wasm32/longjmp.c
@@ -1,6 +1,15 @@
-#include <bits/setjmp.h>
+#include <setjmp.h>
 
-void longjmp(__jmp_buf env, int val) {
-    __builtin_trap();
-    // __builtin_longjmp(env, val);
+// The real longjmp symbol. With the Wasm SjLj pass every longjmp() call is
+// rewritten to __wasm_longjmp() (see wasm_longjmp.c), so this body only runs if
+// a caller was compiled without the pass, where there is no catchpad to unwind
+// to. Kept out of the pass so the _longjmp weak alias below is not rejected as
+// an indirect use of longjmp.
+_Noreturn void longjmp(jmp_buf env, int val)
+{
+	(void)env;
+	(void)val;
+	__builtin_trap();
 }
+
+_Noreturn void _longjmp(jmp_buf, int) __attribute__((__weak__, __alias__("longjmp")));

--- a/src/setjmp/wasm32/setjmp.c
+++ b/src/setjmp/wasm32/setjmp.c
@@ -1,10 +1,64 @@
-#include <bits/setjmp.h>
+#include <stdint.h>
+#include <setjmp.h>
 
-int setjmp(__jmp_buf env) {
-    // return __bultin_setjmp(env);
-    return 0;
+// setjmp/longjmp on wasm are implemented with LLVM's Wasm SjLj lowering (the
+// WebAssemblyLowerEmscriptenEHSjLj pass, enabled by -mllvm -wasm-enable-sjlj).
+// The pass rewrites each setjmp() call site into a call to __wasm_setjmp() and
+// lowers longjmp() into a Wasm exception throw caught back in the setjmping
+// frame (see longjmp.c). These runtime helpers own the jmp_buf layout; the
+// pass only threads the buffer pointer and a per-activation id through them.
+// This mirrors emscripten's system/lib/compiler-rt/emscripten_setjmp.c.
+
+struct __wasm_longjmp_args {
+	void *env;
+	int val;
+};
+
+// Overlaid on the front of __jmp_buf, which is unsigned long long[6] (48 bytes,
+// 8-byte aligned) on wasm32, so this 16-byte struct fits with room to spare.
+struct __jmp_buf_impl {
+	void *func_invocation_id;
+	uint32_t label;
+	struct __wasm_longjmp_args arg;
+};
+
+// Called by the pass at each setjmp() call site: record the setjmp label and
+// the address identifying this function activation into the buffer.
+void __wasm_setjmp(void *env, uint32_t label, void *func_invocation_id)
+{
+	struct __jmp_buf_impl *jb = env;
+	jb->func_invocation_id = func_invocation_id;
+	jb->label = label;
 }
 
-int sigsetjmp(__jmp_buf env, int savesigs) {
-    return 0;
+// Called by the pass in the longjmp catchpad: return the stored label if this
+// buffer belongs to the current activation, otherwise 0 so the longjmp is
+// rethrown to an outer frame.
+uint32_t __wasm_setjmp_test(void *env, void *func_invocation_id)
+{
+	struct __jmp_buf_impl *jb = env;
+	if (jb->func_invocation_id == func_invocation_id)
+		return jb->label;
+	return 0;
+}
+
+// The real setjmp symbol. With the Wasm SjLj pass every setjmp() call is
+// rewritten, so this body only runs if a caller was compiled without the pass,
+// where there is no working longjmp target and returning 0 (the direct return)
+// is the safest fallback.
+int setjmp(jmp_buf env)
+{
+	(void)env;
+	return 0;
+}
+
+int _setjmp(jmp_buf) __attribute__((__weak__, __alias__("setjmp")));
+
+// sigsetjmp is not recognised by the Wasm SjLj pass, so signal-mask
+// save/restore via sigsetjmp/siglongjmp is not yet supported; no-op fallback.
+int sigsetjmp(sigjmp_buf env, int savesigs)
+{
+	(void)env;
+	(void)savesigs;
+	return 0;
 }

--- a/src/setjmp/wasm32/setjmp.c
+++ b/src/setjmp/wasm32/setjmp.c
@@ -53,12 +53,3 @@ int setjmp(jmp_buf env)
 }
 
 int _setjmp(jmp_buf) __attribute__((__weak__, __alias__("setjmp")));
-
-// sigsetjmp is not recognised by the Wasm SjLj pass, so signal-mask
-// save/restore via sigsetjmp/siglongjmp is not yet supported; no-op fallback.
-int sigsetjmp(sigjmp_buf env, int savesigs)
-{
-	(void)env;
-	(void)savesigs;
-	return 0;
-}

--- a/src/setjmp/wasm32/wasm_longjmp.c
+++ b/src/setjmp/wasm32/wasm_longjmp.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+
+// __wasm_longjmp is the target the Wasm SjLj pass lowers every longjmp() call
+// site to. It throws a Wasm exception carrying (env, val); the pass-generated
+// catchpad in the setjmping frame unwinds to it and matches the buffer with
+// __wasm_setjmp_test (see setjmp.c). Kept in its own translation unit compiled
+// with -mllvm -wasm-enable-sjlj so the __builtin_wasm_throw below has the
+// exception-handling feature enabled, without the pass also seeing a real
+// longjmp definition to redirect (which would collide with this symbol).
+
+struct __wasm_longjmp_args {
+	void *env;
+	int val;
+};
+
+// Overlaid on the front of __jmp_buf (see setjmp.c for the layout contract).
+struct __jmp_buf_impl {
+	void *func_invocation_id;
+	uint32_t label;
+	struct __wasm_longjmp_args arg;
+};
+
+// LLVM uses tag 1 (__c_longjmp) for the longjmp exception; the linker
+// synthesises the tag. See llvm/include/llvm/CodeGen/WasmEHFuncInfo.h.
+#define WASM_C_LONGJMP 1
+
+void __wasm_longjmp(void *env, int val)
+{
+	struct __jmp_buf_impl *jb = env;
+	// The C standard forbids longjmp from making setjmp return 0.
+	if (val == 0)
+		val = 1;
+	jb->arg.env = env;
+	jb->arg.val = val;
+	__builtin_wasm_throw(WASM_C_LONGJMP, &jb->arg);
+}

--- a/src/signal/wasm32/siginfo.c
+++ b/src/signal/wasm32/siginfo.c
@@ -1,0 +1,35 @@
+#define _GNU_SOURCE
+#include <signal.h>
+#include <stdint.h>
+
+/* The wasm kernel cannot place a native signal frame on the userspace stack:
+ * handlers run as synchronous host callbacks instead. The runtime calls this
+ * exported trampoline with the portable part of kernel_siginfo_t, and this
+ * function materializes the public objects in userspace before invoking the
+ * application's three-argument handler. */
+__attribute__((visibility("default")))
+void __wasm_call_siginfo_handler(uintptr_t fn, int sig, int code, pid_t pid,
+	uid_t uid, uintptr_t value, int timerid, int overrun)
+{
+	void (*handler)(int, siginfo_t *, void *) = (void *)fn;
+	siginfo_t info = {
+		.si_signo = sig,
+		.si_code = code,
+	};
+
+	/* Register state is not representable for a callback made at the wasm
+	 * syscall boundary. Keep the context valid and intentionally minimal;
+	 * siginfo carries the source information applications depend on. */
+	ucontext_t context = {0};
+
+	if (code == SI_TIMER) {
+		info.si_timerid = timerid;
+		info.si_overrun = overrun;
+		info.si_value.sival_ptr = (void *)value;
+	} else {
+		info.si_pid = pid;
+		info.si_uid = uid;
+	}
+
+	handler(sig, &info, &context);
+}

--- a/src/signal/wasm32/siglongjmp.c
+++ b/src/signal/wasm32/siglongjmp.c
@@ -1,0 +1,11 @@
+#include <setjmp.h>
+#include <signal.h>
+#include "syscall.h"
+
+_Noreturn void siglongjmp(sigjmp_buf jb, int ret)
+{
+	if (jb->__fl && __syscall(SYS_rt_sigprocmask, SIG_SETMASK, jb->__ss,
+	    0, _NSIG/8) < 0)
+		__builtin_trap();
+	longjmp(jb, ret);
+}

--- a/src/signal/wasm32/sigsetjmp.c
+++ b/src/signal/wasm32/sigsetjmp.c
@@ -1,0 +1,22 @@
+#include <setjmp.h>
+#include <signal.h>
+#include "syscall.h"
+
+#undef sigsetjmp
+
+struct __jmp_buf_tag *__wasm_sigsetjmp_prepare(sigjmp_buf jb, int savesigs)
+{
+	jb->__fl = savesigs != 0;
+	if (jb->__fl && __syscall(SYS_rt_sigprocmask, SIG_SETMASK, 0,
+	    jb->__ss, _NSIG/8) < 0)
+		__builtin_trap();
+	return jb;
+}
+
+/* Calls through the ABI symbol cannot provide a caller-side catchpad. */
+int sigsetjmp(sigjmp_buf jb, int savesigs)
+{
+	(void)jb;
+	(void)savesigs;
+	__builtin_trap();
+}

--- a/src/thread/sem_getvalue.c
+++ b/src/thread/sem_getvalue.c
@@ -1,8 +1,22 @@
 #include <semaphore.h>
 #include <limits.h>
+#ifdef __wasm__
+#include "syscall.h"
+#include "wasm_sem.h"
+#endif
 
 int sem_getvalue(sem_t *restrict sem, int *restrict valp)
 {
+#ifdef __wasm__
+	if (__wasm_sem_is_named(sem)) {
+		int value = __syscall_ret(__syscall(SYS_wasm_sem_getvalue,
+			__wasm_sem_fd(sem)));
+
+		if (value < 0) return -1;
+		*valp = value;
+		return 0;
+	}
+#endif
 	int val = sem->__val[0];
 	*valp = val & SEM_VALUE_MAX;
 	return 0;

--- a/src/thread/sem_init.c
+++ b/src/thread/sem_init.c
@@ -11,5 +11,8 @@ int sem_init(sem_t *sem, int pshared, unsigned value)
 	sem->__val[0] = value;
 	sem->__val[1] = 0;
 	sem->__val[2] = pshared ? 0 : 128;
+#ifdef __wasm__
+	sem->__val[3] = 0;
+#endif
 	return 0;
 }

--- a/src/thread/sem_open.c
+++ b/src/thread/sem_open.c
@@ -181,4 +181,58 @@ int sem_close(sem_t *sem)
 	munmap(sem, sizeof *sem);
 	return 0;
 }
+#else
+#include "syscall.h"
+#include "wasm_sem.h"
+
+sem_t *sem_open(const char *name, int flags, ...)
+{
+	char mapped[NAME_MAX+10];
+	unsigned value = 0;
+	mode_t mode = 0;
+	sem_t *sem;
+	va_list ap;
+	long fd;
+
+	if (!(name = __shm_mapname(name, mapped)))
+		return SEM_FAILED;
+	name += 9;
+	flags &= O_CREAT|O_EXCL;
+	if (flags & O_CREAT) {
+		va_start(ap, flags);
+		mode = va_arg(ap, mode_t) & 0666;
+		value = va_arg(ap, unsigned);
+		va_end(ap);
+	} else {
+		flags = 0;
+	}
+
+	sem = malloc(sizeof *sem);
+	if (!sem)
+		return SEM_FAILED;
+	fd = __syscall(SYS_wasm_sem_open, name, flags, mode, value);
+	if (fd < 0) {
+		__libc_free(sem);
+		__syscall_ret(fd);
+		return SEM_FAILED;
+	}
+	sem->__val[0] = fd;
+	sem->__val[1] = 0;
+	sem->__val[2] = 0;
+	sem->__val[3] = WASM_SEM_TAG;
+	return sem;
+}
+
+int sem_close(sem_t *sem)
+{
+	long result;
+
+	if (!__wasm_sem_is_named(sem)) {
+		errno = EINVAL;
+		return -1;
+	}
+	result = __syscall(SYS_close, __wasm_sem_fd(sem));
+	__libc_free(sem);
+	return __syscall_ret(result);
+}
 #endif

--- a/src/thread/sem_post.c
+++ b/src/thread/sem_post.c
@@ -1,9 +1,17 @@
 #include <semaphore.h>
 #include <limits.h>
 #include "pthread_impl.h"
+#ifdef __wasm__
+#include "syscall.h"
+#include "wasm_sem.h"
+#endif
 
 int sem_post(sem_t *sem)
 {
+#ifdef __wasm__
+	if (__wasm_sem_is_named(sem))
+		return syscall(SYS_wasm_sem_post, __wasm_sem_fd(sem));
+#endif
 	int val, new, waiters, priv = sem->__val[2];
 	do {
 		val = sem->__val[0];

--- a/src/thread/sem_timedwait.c
+++ b/src/thread/sem_timedwait.c
@@ -1,6 +1,10 @@
 #include <semaphore.h>
 #include <limits.h>
 #include "pthread_impl.h"
+#ifdef __wasm__
+#include "syscall.h"
+#include "wasm_sem.h"
+#endif
 
 static void cleanup(void *p)
 {
@@ -10,6 +14,23 @@ static void cleanup(void *p)
 int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict at)
 {
 	pthread_testcancel();
+
+#ifdef __wasm__
+	if (__wasm_sem_is_named(sem)) {
+		long result;
+
+		if (at) {
+			long long kernel_time[2] = { at->tv_sec, at->tv_nsec };
+
+			result = __syscall_cp(SYS_wasm_sem_timedwait,
+				__wasm_sem_fd(sem), kernel_time);
+		} else {
+			result = __syscall_cp(SYS_wasm_sem_wait,
+				__wasm_sem_fd(sem));
+		}
+		return __syscall_ret(result);
+	}
+#endif
 
 	if (!sem_trywait(sem)) return 0;
 

--- a/src/thread/sem_trywait.c
+++ b/src/thread/sem_trywait.c
@@ -1,9 +1,17 @@
 #include <semaphore.h>
 #include <limits.h>
 #include "pthread_impl.h"
+#ifdef __wasm__
+#include "syscall.h"
+#include "wasm_sem.h"
+#endif
 
 int sem_trywait(sem_t *sem)
 {
+#ifdef __wasm__
+	if (__wasm_sem_is_named(sem))
+		return syscall(SYS_wasm_sem_trywait, __wasm_sem_fd(sem));
+#endif
 	int val;
 	while ((val=sem->__val[0]) & SEM_VALUE_MAX) {
 		if (a_cas(sem->__val, val, val-1)==val) return 0;

--- a/src/thread/sem_unlink.c
+++ b/src/thread/sem_unlink.c
@@ -1,7 +1,18 @@
 #include <semaphore.h>
 #include <sys/mman.h>
+#ifdef __wasm__
+#include <limits.h>
+#include "syscall.h"
+#endif
 
 int sem_unlink(const char *name)
 {
+#ifdef __wasm__
+	char mapped[NAME_MAX+10];
+
+	if (!(name = __shm_mapname(name, mapped))) return -1;
+	return syscall(SYS_wasm_sem_unlink, name+9);
+#else
 	return shm_unlink(name);
+#endif
 }


### PR DESCRIPTION
this change is made in preparation for adding search domains, for
which higher-level code will need to parse resolv.conf. simply parsing
it twice for each lookup would be one reasonable option, but the
existing parser code was buggy anyway, which suggested to me that it's
a bad idea to have two variants of this code in two different places.

the old code in res_msend potentially misinterpreted overly long lines
in resolv.conf, and stopped parsing after it found 3 nameservers, even
if there were relevant options left to be parsed later in the file.