### PR TITLE
wasm: implement setjmp and longjmp runtime

### DIFF
--- a/arch/wasm32/arch.mak
+++ b/arch/wasm32/arch.mak
@@ -3,3 +3,19 @@ CFLAGS += --target=wasm32 -matomics -mbulk-memory
 LDFLAGS =
 CROSS_COMPILE = llvm-
 LIBCC =
+
+# longjmp is implemented with LLVM's Wasm SjLj lowering. __wasm_longjmp uses
+# __builtin_wasm_throw, and any musl translation unit that itself calls longjmp
+# (siglongjmp) must be compiled with the pass enabled so the call is rewritten.
+# Scoped to these objects so the rest of libc stays free of the Wasm
+# exception-handling feature; a guest only requires it if it uses setjmp.
+#
+# Only wasm_longjmp.c (the __builtin_wasm_throw helper) and siglongjmp.c (which
+# calls longjmp) go through the pass. setjmp.c and longjmp.c are excluded: the
+# setjmp/longjmp helpers are plain memory writes, and running the pass over the
+# real setjmp/longjmp definitions rejects the _setjmp/_longjmp weak aliases as
+# "indirect use of setjmp" or collides with the __wasm_longjmp symbol.
+WASM_SJLJ_OBJS = \
+	obj/src/setjmp/wasm32/wasm_longjmp.o obj/src/setjmp/wasm32/wasm_longjmp.lo \
+	obj/src/signal/wasm32/siglongjmp.o obj/src/signal/wasm32/siglongjmp.lo
+$(WASM_SJLJ_OBJS): CFLAGS_ALL += -mllvm -wasm-enable-sjlj

--- a/arch/wasm32/crt_arch.h
+++ b/arch/wasm32/crt_arch.h
@@ -1,8 +1,4 @@
-struct wasm_process_args {
-	int len, envc, argc;
-	char **argv, **envp;
-	char data[];
-};
+#include "process_args.h"
 
 __attribute__((import_module("linux"), import_name("get_args_length")))
 int wasm_get_args_length(void);
@@ -11,7 +7,7 @@ int wasm_get_args(struct wasm_process_args *buf);
 
 // TODO: malloc this once mmap is fixed
 static char args_buf[65536 * 4];
-static struct wasm_process_args *args = (void*)args_buf;
+hidden struct wasm_process_args *__wasm_process_args = (void*)args_buf;
 
 #ifdef START_is_dlstart
 hidden void _dlstart_c(size_t *sp, size_t *dynv);
@@ -22,19 +18,16 @@ hidden void _dlstart(void) {
 
 #ifdef START_is_start
 void __wasm_call_ctors(void);
-weak int __main_void(void) {
-	int __main_argc_argv(int argc, char **argv);
-	return __main_argc_argv(args->argc, args->argv);
-}
+int __main_void(void);
 hidden void _start_c(long *p);
 hidden void _start(void) {
 	int len = wasm_get_args_length();
 	if (len < 0) __builtin_trap();
 	if (len > sizeof(args_buf)) __builtin_trap();
 
-	if (wasm_get_args(args) < 0) __builtin_trap();
+	if (wasm_get_args(__wasm_process_args) < 0) __builtin_trap();
 
-	__init_libc(args->envp, args->argv[0]);
+	__init_libc(__wasm_process_args->envp, __wasm_process_args->argv[0]);
 	__libc_start_init();
 	__wasm_call_ctors();
 

--- a/arch/wasm32/process_args.h
+++ b/arch/wasm32/process_args.h
@@ -1,0 +1,12 @@
+#ifndef _WASM32_PROCESS_ARGS_H
+#define _WASM32_PROCESS_ARGS_H
+
+struct wasm_process_args {
+	int len, envc, argc;
+	char **argv, **envp;
+	char data[];
+};
+
+extern hidden struct wasm_process_args *__wasm_process_args;
+
+#endif

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -27,6 +27,12 @@ typedef struct __jmp_buf_tag {
 typedef jmp_buf sigjmp_buf;
 int sigsetjmp (sigjmp_buf, int) __setjmp_attr;
 _Noreturn void siglongjmp (sigjmp_buf, int);
+#ifdef __wasm__
+struct __jmp_buf_tag *__wasm_sigsetjmp_prepare(sigjmp_buf, int);
+/* LLVM's Wasm SjLj pass must see setjmp directly in the caller. */
+#define sigsetjmp(env, savemask) \
+	setjmp(__wasm_sigsetjmp_prepare((env), (savemask)))
+#endif
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \

--- a/src/env/wasm32/__main_argc_argv.c
+++ b/src/env/wasm32/__main_argc_argv.c
@@ -1,0 +1,9 @@
+#include <features.h>
+#include "process_args.h"
+
+int __main_argc_argv_envp(int, char **, char **);
+
+weak int __main_argc_argv(int argc, char **argv)
+{
+	return __main_argc_argv_envp(argc, argv, __wasm_process_args->envp);
+}

--- a/src/env/wasm32/__main_void.c
+++ b/src/env/wasm32/__main_void.c
@@ -1,0 +1,10 @@
+#include <features.h>
+#include "process_args.h"
+
+int __main_argc_argv(int, char **);
+
+weak int __main_void(void)
+{
+	return __main_argc_argv(__wasm_process_args->argc,
+		__wasm_process_args->argv);
+}

--- a/src/setjmp/wasm32/longjmp.c
+++ b/src/setjmp/wasm32/longjmp.c
@@ -1,6 +1,15 @@
-#include <bits/setjmp.h>
+#include <setjmp.h>
 
-void longjmp(__jmp_buf env, int val) {
-    __builtin_trap();
-    // __builtin_longjmp(env, val);
+// The real longjmp symbol. With the Wasm SjLj pass every longjmp() call is
+// rewritten to __wasm_longjmp() (see wasm_longjmp.c), so this body only runs if
+// a caller was compiled without the pass, where there is no catchpad to unwind
+// to. Kept out of the pass so the _longjmp weak alias below is not rejected as
+// an indirect use of longjmp.
+_Noreturn void longjmp(jmp_buf env, int val)
+{
+	(void)env;
+	(void)val;
+	__builtin_trap();
 }
+
+_Noreturn void _longjmp(jmp_buf, int) __attribute__((__weak__, __alias__("longjmp")));

--- a/src/setjmp/wasm32/setjmp.c
+++ b/src/setjmp/wasm32/setjmp.c
@@ -1,10 +1,55 @@
-#include <bits/setjmp.h>
+#include <stdint.h>
+#include <setjmp.h>
 
-int setjmp(__jmp_buf env) {
-    // return __bultin_setjmp(env);
-    return 0;
+// setjmp/longjmp on wasm are implemented with LLVM's Wasm SjLj lowering (the
+// WebAssemblyLowerEmscriptenEHSjLj pass, enabled by -mllvm -wasm-enable-sjlj).
+// The pass rewrites each setjmp() call site into a call to __wasm_setjmp() and
+// lowers longjmp() into a Wasm exception throw caught back in the setjmping
+// frame (see longjmp.c). These runtime helpers own the jmp_buf layout; the
+// pass only threads the buffer pointer and a per-activation id through them.
+// This mirrors emscripten's system/lib/compiler-rt/emscripten_setjmp.c.
+
+struct __wasm_longjmp_args {
+	void *env;
+	int val;
+};
+
+// Overlaid on the front of __jmp_buf, which is unsigned long long[6] (48 bytes,
+// 8-byte aligned) on wasm32, so this 16-byte struct fits with room to spare.
+struct __jmp_buf_impl {
+	void *func_invocation_id;
+	uint32_t label;
+	struct __wasm_longjmp_args arg;
+};
+
+// Called by the pass at each setjmp() call site: record the setjmp label and
+// the address identifying this function activation into the buffer.
+void __wasm_setjmp(void *env, uint32_t label, void *func_invocation_id)
+{
+	struct __jmp_buf_impl *jb = env;
+	jb->func_invocation_id = func_invocation_id;
+	jb->label = label;
 }
 
-int sigsetjmp(__jmp_buf env, int savesigs) {
-    return 0;
+// Called by the pass in the longjmp catchpad: return the stored label if this
+// buffer belongs to the current activation, otherwise 0 so the longjmp is
+// rethrown to an outer frame.
+uint32_t __wasm_setjmp_test(void *env, void *func_invocation_id)
+{
+	struct __jmp_buf_impl *jb = env;
+	if (jb->func_invocation_id == func_invocation_id)
+		return jb->label;
+	return 0;
 }
+
+// The real setjmp symbol. With the Wasm SjLj pass every setjmp() call is
+// rewritten, so this body only runs if a caller was compiled without the pass,
+// where there is no working longjmp target and returning 0 (the direct return)
+// is the safest fallback.
+int setjmp(jmp_buf env)
+{
+	(void)env;
+	return 0;
+}
+
+int _setjmp(jmp_buf) __attribute__((__weak__, __alias__("setjmp")));

--- a/src/setjmp/wasm32/wasm_longjmp.c
+++ b/src/setjmp/wasm32/wasm_longjmp.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+
+// __wasm_longjmp is the target the Wasm SjLj pass lowers every longjmp() call
+// site to. It throws a Wasm exception carrying (env, val); the pass-generated
+// catchpad in the setjmping frame unwinds to it and matches the buffer with
+// __wasm_setjmp_test (see setjmp.c). Kept in its own translation unit compiled
+// with -mllvm -wasm-enable-sjlj so the __builtin_wasm_throw below has the
+// exception-handling feature enabled, without the pass also seeing a real
+// longjmp definition to redirect (which would collide with this symbol).
+
+struct __wasm_longjmp_args {
+	void *env;
+	int val;
+};
+
+// Overlaid on the front of __jmp_buf (see setjmp.c for the layout contract).
+struct __jmp_buf_impl {
+	void *func_invocation_id;
+	uint32_t label;
+	struct __wasm_longjmp_args arg;
+};
+
+// LLVM uses tag 1 (__c_longjmp) for the longjmp exception; the linker
+// synthesises the tag. See llvm/include/llvm/CodeGen/WasmEHFuncInfo.h.
+#define WASM_C_LONGJMP 1
+
+void __wasm_longjmp(void *env, int val)
+{
+	struct __jmp_buf_impl *jb = env;
+	// The C standard forbids longjmp from making setjmp return 0.
+	if (val == 0)
+		val = 1;
+	jb->arg.env = env;
+	jb->arg.val = val;
+	__builtin_wasm_throw(WASM_C_LONGJMP, &jb->arg);
+}

--- a/src/signal/wasm32/restore.c
+++ b/src/signal/wasm32/restore.c
@@ -1,0 +1,30 @@
+#define _GNU_SOURCE
+#include <features.h>
+#include <signal.h>
+#include <stdint.h>
+
+__attribute__((import_module("linux"), import_name("copy_siginfo")))
+int __wasm_copy_siginfo(siginfo_t *);
+
+hidden void __restore(void)
+{
+}
+
+/* Signal delivery is a synchronous host callback, so there is no native
+ * signal frame to restore. Instead, the kernel calls this restorer as the
+ * userspace trampoline. It materializes the public objects before invoking
+ * the application's three-argument handler. */
+hidden void __restore_rt(uintptr_t fn, int sig)
+{
+	void (*handler)(int, siginfo_t *, void *) = (void *)fn;
+	siginfo_t info;
+
+	/* Register state is not representable for a callback made at the wasm
+	 * syscall boundary. Keep the context valid and intentionally minimal;
+	 * siginfo carries the source information applications depend on. */
+	ucontext_t context = {0};
+
+	if (__wasm_copy_siginfo(&info)) return;
+
+	handler(sig, &info, &context);
+}

--- a/src/signal/wasm32/siglongjmp.c
+++ b/src/signal/wasm32/siglongjmp.c
@@ -1,0 +1,11 @@
+#include <setjmp.h>
+#include <signal.h>
+#include "syscall.h"
+
+_Noreturn void siglongjmp(sigjmp_buf jb, int ret)
+{
+	if (jb->__fl && __syscall(SYS_rt_sigprocmask, SIG_SETMASK, jb->__ss,
+	    0, _NSIG/8) < 0)
+		__builtin_trap();
+	longjmp(jb, ret);
+}

--- a/src/signal/wasm32/sigsetjmp.c
+++ b/src/signal/wasm32/sigsetjmp.c
@@ -1,0 +1,22 @@
+#include <setjmp.h>
+#include <signal.h>
+#include "syscall.h"
+
+#undef sigsetjmp
+
+struct __jmp_buf_tag *__wasm_sigsetjmp_prepare(sigjmp_buf jb, int savesigs)
+{
+	jb->__fl = savesigs != 0;
+	if (jb->__fl && __syscall(SYS_rt_sigprocmask, SIG_SETMASK, 0,
+	    jb->__ss, _NSIG/8) < 0)
+		__builtin_trap();
+	return jb;
+}
+
+/* Calls through the ABI symbol cannot provide a caller-side catchpad. */
+int sigsetjmp(sigjmp_buf jb, int savesigs)
+{
+	(void)jb;
+	(void)savesigs;
+	__builtin_trap();
+}


### PR DESCRIPTION

llvm has special lowering support for SjLj on wasm, which needs a specific
runtime provided by the libc

<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/musl/pull/7 :point_left:
- https://github.com/tombl/musl/pull/6
<!-- /jj-pr stack navigation -->